### PR TITLE
Update _SimpleConsensus to use static autograd methods (for PyTorch >1.3)

### DIFF
--- a/mmaction/models/tenons/segmental_consensuses/simple_consensus.py
+++ b/mmaction/models/tenons/segmental_consensuses/simple_consensus.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
+
 from ...registry import SEGMENTAL_CONSENSUSES
 
 

--- a/mmaction/models/tenons/segmental_consensuses/simple_consensus.py
+++ b/mmaction/models/tenons/segmental_consensuses/simple_consensus.py
@@ -1,33 +1,26 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from ...registry import SEGMENTAL_CONSENSUSES
 
 
 class _SimpleConsensus(torch.autograd.Function):
     """Simplest segmental consensus module"""
 
-    def __init__(self,
-                 consensus_type='avg',
-                 dim=1):
-        super(_SimpleConsensus, self).__init__()
-
-        assert consensus_type in ['avg']
-        self.consensus_type = consensus_type
-        self.dim = dim
-        self.shape = None
-
-    def forward(self, x):
-        self.shape = x.size()
-        if self.consensus_type == 'avg':
-            output = x.mean(dim=self.dim, keepdim=True)
+    @staticmethod
+    def forward(ctx, x, dim, consensus_type):
+        ctx.save_for_backward(x, dim, consensus_type)
+        if consensus_type == 'avg':
+            output = x.mean(dim=dim, keepdim=True)
         else:
             output = None
         return output
 
-    def backward(self, grad_output):
-        if self.consensus_type == 'avg':
-            grad_in = grad_output.expand(self.shape) / float(self.shape[self.dim])
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, dim, consensus_type = ctx.saved_tensors
+        shape = x.size()
+        if consensus_type == 'avg':
+            grad_in = grad_output.expand(shape) / float(shape[dim])
         else:
             grad_in = None
         return grad_in
@@ -46,4 +39,6 @@ class SimpleConsensus(nn.Module):
         pass
 
     def forward(self, input):
-        return _SimpleConsensus(self.consensus_type, self.dim)(input)
+        return _SimpleConsensus.apply(input,
+                                    self.dim,
+                                    self.consensus_type)


### PR DESCRIPTION
Thank you so much for sharing your implementation of TPN!

## Problem

I've been trying to get it to work in one of my own projects -- however, I ran into the same issue as mentioned #28, in which the user pastes a stack trace with error message `"Legacy autograd function with non-static forward method is deprecated."` This occurs when you try to call `forward()` with the old code when the averaging consensus (`_SimpleConsensus`) is used.

## Environment

* PyTorch 1.7.0 + CUDA 11.0
* Ubuntu 16.04.2 LTS
* Python 3.7.8

## Summary of changes

In order to make the `_SimpleConsensus` class (subclassing `torch.Autograd.Function`) compatible with PyTorch >1.3:
* Removed `__init__` method from `_SimpleConsensus`
* Use `apply` static method instead of `forward` for passing input tensor through the `_SimpleConsensus` object
* `forward()` method of `_SimpleConsensus` uses `ctx.save_for_backward(args)` to cache input tensor `x`, `dim`, and `consensus_type`.
* `self.shape` is no longer a member of `_SimpleConsensus`; it is reconstructed by retrieving `x` from `ctx.saved_tensors` and calling `x.size()` in each call to `backward()`.

This is consistent with the template given in the [PyTorch docs](https://pytorch.org/docs/stable/autograd.html#torch.autograd.Function), which I referenced.

## Discussion

The changes in this PR work for me -- I am able to run `forward()` without issue now. However, as a disclaimer, due to the nature of my project, I'm using my own testing script instead of the provided testing framework in this repo. For completeness, my model loading code looks like this:

```
from TPN.mmaction.models.recognizers import TSN3D
import torch

PRETRAINED_MODEL_PATH = "/path/to/my/model/kinetics400_tpn_r50f32s2.pth"
model = TSN3D(model_cfg["backbone"], necks=model_cfg["necks"], cls_head=model_cfg["cls_head"],
             spatial_temporal_module=model_cfg["spatial_temporal_module"],
              segmental_consensus=model_cfg["segmental_consensus"])
pretrained = torch.load(PRETRAINED_MODEL_PATH)
model.load_state_dict(pretrained)
```

Please let me know if there's any additional testing (suites or otherwise) I should run, or if there's a contributing guide that I've overlooked. Furthermore, I'm happy to provide more details as needed. Thanks!